### PR TITLE
fix bolt_encode when nrows = multiples of 32

### DIFF
--- a/cpp/src/quantize/bolt.hpp
+++ b/cpp/src/quantize/bolt.hpp
@@ -57,6 +57,9 @@ void bolt_encode(const float* X, int64_t nrows, int ncols,
     for (int b = 0; b < nblocks; b++) { // for each block
         // handle nrows not a multiple of 32
         int limit = (b == (nblocks - 1)) ? (nrows % 32) : block_rows;
+        if (limit == 0) {
+            limit = block_rows;
+        }
         for (int n = 0; n < limit; n++) { // for each row in block
 
             auto centroids_ptr = centroids;


### PR DESCRIPTION
Hi. I found that there is a tiny issue in bolt_encode when nrows = multiples of 32.

For simplicity, consider the case where nrows = 32. Then nblocks evaluates to be 1. Hence, the statement "int limit = (b == (nblocks - 1)) ? (nrows % 32) : block_rows;" assigns 0 to limit which should be 32 instead. As a result, the very last block (if it has exactly 32 rows) will not be computed.

Hope the above makes sense and correct me if I made any stupid mistake.