### PR TITLE
Changes to build mithral with bazel

### DIFF
--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -1,8 +1,7 @@
-
 cc_binary(
     name = "main",
-    srcs = ['test/main.cpp'] + glob(['test/*/*.hpp']) + glob(['test/*/*.cpp']), # + glob(["test/external/catch.hpp"]) +
-    deps = [':bolt', ':testing_utils'],
+    srcs = ['test/main.cpp'] + glob(['test/*/*.hpp']) + glob(['test/quantize/test*.cpp']), # + glob(["test/external/catch.hpp"]) +
+    deps = [':bolt', ':testing_utils', ':mithral'], 
     copts = ['-O3', '-march=native', '-mavx', '-ffast-math', '-std=c++14'],
     defines = ['BLAZE', 'NDEBUG'],
 )
@@ -10,7 +9,15 @@ cc_binary(
 cc_library(
     name = "bolt",
     srcs = ['src/quantize/bolt.cpp'],
-    hdrs = glob(['src/*/*.hpp']) + glob(['src/external/eigen/**']),
+    hdrs = glob(['src/*.hpp']) + glob(['src/*/*.hpp']) + glob(['src/external/eigen/**']),
+    copts = ['-O3', '-march=native', '-mavx', '-ffast-math', '-std=c++14'],
+    defines = ['BLAZE', 'NDEBUG'],
+)
+
+cc_library(
+    name = "mithral",
+    srcs = ['src/quantize/mithral.cpp'],
+    hdrs = glob(['src/*.hpp']) + glob(['src/*/*.hpp']) + glob(['src/external/eigen/**']),
     copts = ['-O3', '-march=native', '-mavx', '-ffast-math', '-std=c++14'],
     defines = ['BLAZE', 'NDEBUG'],
 )

--- a/cpp/src/external/eigen/unsupported/Eigen/CXX11/Tensor
+++ b/cpp/src/external/eigen/unsupported/Eigen/CXX11/Tensor
@@ -25,7 +25,7 @@
 #include <utility>
 #endif
 
-#include <Eigen/src/Core/util/DisableStupidWarnings.h>
+#include "../../../Eigen/src/Core/util/DisableStupidWarnings.h"
 
 #include "../SpecialFunctions"
 #include "src/util/CXX11Meta.h"
@@ -149,6 +149,6 @@ typedef unsigned __int64 uint64_t;
 
 #include "src/Tensor/TensorIO.h"
 
-#include <Eigen/src/Core/util/ReenableStupidWarnings.h>
+#include "../../../Eigen/src/Core/util/ReenableStupidWarnings.h"
 
 //#endif // EIGEN_CXX11_TENSOR_MODULE

--- a/cpp/src/include/public.hpp
+++ b/cpp/src/include/public.hpp
@@ -13,7 +13,7 @@
 #include <vector>
 
 #ifdef BLAZE
-    #include "src/external/eigen/Core"
+    #include "src/external/eigen/Eigen/Core"
     #include "src/utils/eigen_utils.hpp"
 #else
     #include "Core"

--- a/cpp/src/quantize/bolt.hpp
+++ b/cpp/src/quantize/bolt.hpp
@@ -15,8 +15,6 @@
 #include <type_traits>
 #include "immintrin.h" // this is what defines all the simd funcs + _MM_SHUFFLE
 
-#include "debug_utils.hpp" // TODO rm
-
 #ifdef BLAZE
     #include "src/utils/avx_utils.hpp"
 #else

--- a/cpp/src/quantize/mithral.hpp
+++ b/cpp/src/quantize/mithral.hpp
@@ -15,8 +15,6 @@
 #include <limits>
 #include "immintrin.h"
 
-#include "debug_utils.hpp" // TODO rm
-
 // #define MITHRAL_USE_BOLT_SAFE_SCAN // way slower, but exact sum of uint8s
 
 #ifdef BLAZE

--- a/cpp/src/quantize/mithral_v1.hpp
+++ b/cpp/src/quantize/mithral_v1.hpp
@@ -15,8 +15,6 @@
 #include <limits>
 #include "immintrin.h"
 
-#include "debug_utils.hpp" // TODO rm
-
 #ifdef BLAZE
     #include "src/utils/avx_utils.hpp"
 #else

--- a/cpp/src/utils/avx_utils.cpp
+++ b/cpp/src/utils/avx_utils.cpp
@@ -1,5 +1,10 @@
 
-#include "avx_utils.hpp"
+#ifdef BLAZE
+	//#include "src/utils/avx_utils.hpp"
+	#include "avx_utils.hpp"
+#else
+	#include "avx_utils.hpp"
+#endif
 
 // N has to be a multiple of 8; better if D a multiple of 3 or 4, M a multiple
 // of 2 or 3

--- a/cpp/src/utils/eigen_utils.hpp
+++ b/cpp/src/utils/eigen_utils.hpp
@@ -11,8 +11,8 @@
 #define EIGEN_DONT_PARALLELIZE // ensure no multithreading
 
 #ifdef BLAZE  // bazel can't deal with pretending stuff is in same dir
-    #include "src/external/eigen/Dense"
-   #include <src/external/eigen/unsupported/Eigen/CXX11/Tensor>
+    #include "src/external/eigen/Eigen/Dense"
+   #include "src/external/eigen/unsupported/Eigen/CXX11/Tensor"
 #else
     #include "Dense"
     #include "unsupported/Eigen/CXX11/Tensor"

--- a/cpp/src/utils/memory.hpp
+++ b/cpp/src/utils/memory.hpp
@@ -10,7 +10,7 @@
 #define __DIG_MEMORY_HPP
 
 #ifdef BLAZE
-    #include "src/external/eigen/Core"
+    #include "src/external/eigen/Eigen/Core"
 #else
     #include "Core"  // minimal subset of EIGEN that will compile
 #endif

--- a/cpp/src/utils/nn_utils.hpp
+++ b/cpp/src/utils/nn_utils.hpp
@@ -13,7 +13,7 @@
 
 // #include "Dense"
 #ifdef BLAZE
-    #include "src/external/eigen/Dense"
+    #include "src/external/eigen/Eigen/Dense"
     #include "src/include/public.hpp"  // for Neighbor
 #else
     #include "Dense"

--- a/cpp/test/quantize/profile_amm.hpp
+++ b/cpp/test/quantize/profile_amm.hpp
@@ -11,7 +11,7 @@
 
 #ifdef BLAZE
     #include "test/quantize/amm_common.hpp"
-    #include "src/external/eigen/SparseCore"
+    #include "src/external/eigen/Eigen/SparseCore"
 #else
     #include "amm_common.hpp"
     #include "SparseCore"

--- a/cpp/test/quantize/test_multicodebook.cpp
+++ b/cpp/test/quantize/test_multicodebook.cpp
@@ -3,7 +3,7 @@
 #ifdef BLAZE
     #include "test/external/catch.hpp"
     #include "src/quantize/multi_codebook.hpp"
-    #include "src/external/eigen/Dense"
+    #include "src/external/eigen/Eigen/Dense"
     #include "src/utils/eigen_utils.hpp"
     #include "src/utils/debug_utils.hpp"
     #include "src/utils/bit_ops.hpp"


### PR DESCRIPTION
This contains some modifications to `#include`s and to the BUILD file.

Note: I changed `glob(['test/quantize/*.cpp'])` to `glob(['test/quantize/test*.cpp'])` because I was getting linker errors with `sgemm_colmajor`:

```
Undefined symbols for architecture x86_64:
  "sgemm_colmajor(float const*, float const*, int, int, int, float*)", referenced from:
      (anonymous namespace)::_profile_matmul_methods(std::__1::vector<int, std::__1::allocator<int> >, MatmulTaskShape) in profile_amm.o
      _profile_matmul(char const*, unsigned int, unsigned int, unsigned int) in profile_amm_old.o
      _profile_sketch_matmul_fixedW(char const*, unsigned int, unsigned int, unsigned int, unsigned int) in profile_amm_old.o
      _profile_sketch_matmul(char const*, unsigned int, unsigned int, unsigned int, unsigned int) in profile_amm_old.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Error in child process '/usr/bin/xcrun'. 1
external/local_config_cc/cc_wrapper.sh: line 69:  6279 Abort trap: 6           "$(/usr/bin/dirname "$0")"/wrapped_clang "$@"
Target //:main failed to build
```

I was unable to fix the linker errors, but `sgemm_colmajor` seems to be no longer relevant, if I'm understanding things correctly.  